### PR TITLE
Add name property to verified snaps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,9 @@ const VerifiedSnapVersionStruct = object({
 
 export const VerifiedSnapStruct = object({
   id: string(),
-  name: string(),
+  metadata: object({
+    name: string(),
+  }),
   versions: record(VersionStruct, VerifiedSnapVersionStruct),
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ const VerifiedSnapVersionStruct = object({
 
 export const VerifiedSnapStruct = object({
   id: string(),
+  name: string(),
   versions: record(VersionStruct, VerifiedSnapVersionStruct),
 });
 


### PR DESCRIPTION
This adds a `name` property to verified Snaps, for displaying in the UI upon installation.

Related to: MetaMask/MetaMask-planning#298.