### PR TITLE
API-226: update action for pushing registry artifacts to remote storage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,8 @@ jobs:
       contents: read
       id-token: write # Required for requesting the OIDC JWT for cloud access token
     uses: ./.github/workflows/publish-registry.yml
+    with:
+      publish-environment: deploy-prod # Use prod for now until we split into nightlies, flask and stable
     secrets:
       REGISTRY_PRIVATE_KEY: ${{ secrets.REGISTRY_PRIVATE_KEY }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,7 @@ jobs:
     name: Publish release
     permissions:
       contents: write
+      id-token: write # Required for requesting the OIDC JWT for cloud access token
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download actionlint
         id: download-actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.22
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23
         shell: bash
       - name: Check workflow files
         run: ${{ steps.download-actionlint.outputs.executable }} -color

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,9 @@ jobs:
     # Filtering by `push` events ensures that we only release from the `main` branch.
     if: github.event_name == 'push'
     needs: all-jobs-pass
+    permissions:
+      contents: read
+      id-token: write # Required for requesting the OIDC JWT for cloud access token
     uses: ./.github/workflows/publish-registry.yml
     secrets:
       REGISTRY_PRIVATE_KEY: ${{ secrets.REGISTRY_PRIVATE_KEY }}
@@ -78,7 +81,6 @@ jobs:
     name: Publish release
     permissions:
       contents: write
-      id-token: write # Required for requesting the OIDC JWT for cloud access token
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,6 @@ jobs:
     uses: ./.github/workflows/publish-registry.yml
     secrets:
       REGISTRY_PRIVATE_KEY: ${{ secrets.REGISTRY_PRIVATE_KEY }}
-      METAMASKBOT_TOKEN: ${{ secrets.METAMASKBOT_TOKEN }}
 
   is-release:
     # Filtering by `push` events ensures that we only release from the `main` branch, which is a

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -2,6 +2,10 @@ name: Publish Registry
 
 on:
   workflow_call:
+    inputs:
+      publish-environment:
+        required: true
+        type: string
     secrets:
       REGISTRY_PRIVATE_KEY:
         required: true
@@ -27,7 +31,7 @@ jobs:
 
   publish-registry:
     name: Deploy registry to remote storage
-    environment: registry-publish
+    environment: $({ inputs.publish-environment })
     needs: check-updated
     if: ${{ needs.check-updated.outputs.UPDATED == 'true' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -5,8 +5,6 @@ on:
     secrets:
       REGISTRY_PRIVATE_KEY:
         required: true
-      METAMASKBOT_TOKEN:
-        required: true
 
 jobs:
   check-updated:
@@ -50,9 +48,10 @@ jobs:
           mkdir -p dist
           cp src/registry.json dist/registry.json
           cp src/signature.json dist/signature.json
-      - name: Deploy registry
-        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
-        with:
-          personal_token: ${{ secrets.METAMASKBOT_TOKEN }}
-          publish_dir: ./dist
-          destination_dir: latest
+
+#      - name: Deploy registry
+#        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
+#        with:
+#          personal_token: ${{ secrets.METAMASKBOT_TOKEN }}
+#          publish_dir: ./dist
+#          destination_dir: latest

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Deploy registry
         run: |
           aws s3 cp ./dist s3://${{ vars.AWS_BUCKET_NAME }}/latest --recursive --acl private
-          # TODO: CF invalidation
+          aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CF_DISTRIBUTION_ID }} --paths "/latest"

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -26,7 +26,7 @@ jobs:
           fi
 
   publish-registry:
-    name: Deploy registry to `gh-pages` branch
+    name: Deploy registry to remote storage
     environment: registry-publish
     needs: check-updated
     if: ${{ needs.check-updated.outputs.UPDATED == 'true' }}
@@ -48,10 +48,12 @@ jobs:
           mkdir -p dist
           cp src/registry.json dist/registry.json
           cp src/signature.json dist/signature.json
-
-#      - name: Deploy registry
-#        uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
-#        with:
-#          personal_token: ${{ secrets.METAMASKBOT_TOKEN }}
-#          publish_dir: ./dist
-#          destination_dir: latest
+      - name: configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-session-name: ghactionssession
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Deploy registry
+        run: |
+          aws s3 cp ./dist s3://${{ vars.AWS_BUCKET_NAME }}/latest --recursive --acl private

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -49,7 +49,7 @@ jobs:
           cp src/registry.json dist/registry.json
           cp src/signature.json dist/signature.json
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           role-session-name: ghactionssession
@@ -57,3 +57,4 @@ jobs:
       - name: Deploy registry
         run: |
           aws s3 cp ./dist s3://${{ vars.AWS_BUCKET_NAME }}/latest --recursive --acl private
+          # TODO: CF invalidation


### PR DESCRIPTION
What is the current state of things and why does it need to change?
Artifacts are published to gh-pages

What is the solution your changes offer and how does it work?
Deploy registry files to remote storage and creates CF invalidation right after it.

aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef action has to be whitelisted

See: API-226

