### PR TITLE
Fix private key trying to be loaded from path before env first.

### DIFF
--- a/scripts/sign-registry.ts
+++ b/scripts/sign-registry.ts
@@ -26,14 +26,14 @@ async function getPrivateKey() {
   const privateKeyPath = process.env.PRIVATE_KEY_PATH;
   const privateKeyEnv = process.env.REGISTRY_PRIVATE_KEY;
 
-  if (privateKeyPath) {
-    console.log('Using key from PRIVATE_KEY_PATH file.');
-    return await fs.readFile(privateKeyPath, 'utf-8').then((key) => key.trim());
-  }
-
   if (privateKeyEnv) {
     console.log('Using key from REGISTRY_PRIVATE_KEY variable.');
     return privateKeyEnv;
+  }
+
+  if (privateKeyPath) {
+    console.log('Using key from PRIVATE_KEY_PATH file.');
+    return await fs.readFile(privateKeyPath, 'utf-8').then((key) => key.trim());
   }
 
   throw new Error(

--- a/scripts/verify-registry.ts
+++ b/scripts/verify-registry.ts
@@ -18,14 +18,14 @@ async function getPublicKey() {
   const publicKeyPath = process.env.PUBLIC_KEY_PATH;
   const registryPublicKey = process.env.REGISTRY_PUBLIC_KEY;
 
-  if (publicKeyPath) {
-    console.log('Using key from PUBLIC_KEY_PATH file.');
-    return await fs.readFile(publicKeyPath, 'utf-8').then((key) => key.trim());
-  }
-
   if (registryPublicKey) {
     console.log('Using key from REGISTRY_PUBLIC_KEY variable.');
     return registryPublicKey;
+  }
+
+  if (publicKeyPath) {
+    console.log('Using key from PUBLIC_KEY_PATH file.');
+    return await fs.readFile(publicKeyPath, 'utf-8').then((key) => key.trim());
   }
 
   throw new Error(

--- a/src/registry.json
+++ b/src/registry.json
@@ -1,5 +1,4 @@
 {
-  "verifiedSnaps": {},
   "blockedSnaps": [
     {
       "id": "npm:@consensys/starknet-snap",
@@ -8,5 +7,6 @@
     {
       "checksum": "A83r5/ZIcKuKwuAnQHHByVFCuofj7jGK5hOStmHY6A0="
     }
-  ]
+  ],
+  "verifiedSnaps": {}
 }


### PR DESCRIPTION
.env was set, used for other envs, which blocked private key from being used.

Also updated registry.json to trigger CI

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
