### PR TITLE
Refactor assertHexString function to use isStrictHexString

### DIFF
--- a/scripts/verify-registry.ts
+++ b/scripts/verify-registry.ts
@@ -1,4 +1,4 @@
-import { assert, assertStruct, Hex, isHexString } from '@metamask/utils';
+import { assert, assertStruct, isStrictHexString } from '@metamask/utils';
 import * as dotenv from 'dotenv';
 import { promises as fs } from 'fs';
 
@@ -34,19 +34,6 @@ async function getPublicKey() {
 }
 
 /**
- * Asserts that the provided value is a string starting with 0x.
- *
- * @param value - The value under test.
- * @param errorMessage - The error message to throw if it's not a hex string.
- */
-function assertHexString(
-  value: unknown,
-  errorMessage = 'Value must be a hex string',
-): asserts value is Hex {
-  assert(isHexString(value), errorMessage);
-}
-
-/**
  * Verify the signature of the registry.
  */
 async function main() {
@@ -63,7 +50,7 @@ async function main() {
   );
 
   const publicKey = await getPublicKey();
-  assertHexString(publicKey, 'Public key must be a hex string.');
+  assert(isStrictHexString(publicKey), 'Public key must be a hex string.');
 
   const signature = JSON.parse(await fs.readFile(signaturePath, 'utf-8'));
   assertStruct(signature, SignatureStruct);


### PR DESCRIPTION
## Description

This pull request refactors the `assertHexString` function to use the `isStrictHexString` function provided by the
`@metamask/utils` package.

In the previous implementation, the `assertHexString` function was used to assert that a given string is a valid
hexadecimal string. However, the same functionality is already provided by the `isStrictHexString` function provided
by the `@metamask/utils` package.

Therefore, we have removed the `assertHexString` function and replaced all its occurrences with calls to `isStrictHexString`.

## Changes

1. Replace `assertHexString` function with calls to `isStrictHexString`.