### PR TITLE
Fix BIP-32 example checksums

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -29,7 +29,7 @@
       },
       "versions": {
         "0.37.2-flask.1": {
-          "checksum": "UWS774A057OPPbfbF560vMKxWamt+1/oxxtaKyw6Ygk="
+          "checksum": "9zlU1HnaCKIKeIYLWAZMpKKGhniZz3uCfL6lMi6HxmU="
         }
       }
     },

--- a/src/registry.json
+++ b/src/registry.json
@@ -28,6 +28,12 @@
         "name": "BIP-32 Example Snap"
       },
       "versions": {
+        "0.35.0-flask.1": {
+          "checksum": "nSL22rF7OWVCYzaj9B+7tUgRWCw8oMfi2r0utoJH6rg="
+        },
+        "0.35.2-flask.1": {
+          "checksum": "cOJYxa17Mn160j/YH8887WOpGFVl0N0c2TK4WBfpdh0="
+        },
         "0.37.2-flask.1": {
           "checksum": "9zlU1HnaCKIKeIYLWAZMpKKGhniZz3uCfL6lMi6HxmU="
         }


### PR DESCRIPTION
Fixes a mistake in the BIP-32 example checksum.

Also adds some older versions that are used in testing.