### PR TITLE
Add new snap metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export const VerifiedSnapStruct = object({
     website: optional(string()),
     summary: optional(string()),
     description: optional(string()),
-    reports: optional(array(string())),
+    audits: optional(array(string())),
     tags: optional(array(string())),
   }),
   versions: record(VersionStruct, VerifiedSnapVersionStruct),

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,8 @@ export const VerifiedSnapStruct = object({
     description: optional(string()),
     audits: optional(array(string())),
     tags: optional(array(string())),
+    support: optional(string()),
+    sourceCode: optional(string()),
   }),
   versions: record(VersionStruct, VerifiedSnapVersionStruct),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   union,
   optional,
   Infer,
+  enums,
 } from 'superstruct';
 
 const VerifiedSnapVersionStruct = object({
@@ -21,6 +22,13 @@ export const VerifiedSnapStruct = object({
   id: string(),
   metadata: object({
     name: string(),
+    type: optional(enums(['account'])),
+    author: optional(string()),
+    website: optional(string()),
+    summary: optional(string()),
+    description: optional(string()),
+    reports: optional(array(string())),
+    tags: optional(array(string())),
   }),
   versions: record(VersionStruct, VerifiedSnapVersionStruct),
 });

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -25,7 +25,80 @@ describe('Snaps Registry', () => {
               'https://metamask.io/example/report-1.pdf',
               'https://metamask.io/example/report-2.pdf',
             ],
+            support: 'https://metamask.io/example/support',
+            sourceCode: 'https://metamask.io/example/source-code',
             tags: ['accounts', 'example'],
+          },
+          versions: {
+            '0.1.0': {
+              checksum: 'A83r5/ZIcKeKw3An13HBeV4CAofj7jGK5hOStmHY6A0=',
+            },
+          },
+        },
+      },
+      blockedSnaps: [
+        {
+          id: 'npm:example-blocked-snap',
+          versionRange: '^0.1.0',
+          reason: {
+            explanation: 'Example explanation',
+            url: 'https://metamask.io/example/explanation',
+          },
+        },
+        {
+          checksum: 'B3ar53ZIcKeKw3An3aqBeV4CAofj7jGK5hOAAxQY6A0=',
+          reason: {
+            explanation: 'Example explanation',
+            url: 'https://metamask.io/example/explanation',
+          },
+        },
+      ],
+    };
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    expect(() => assert(registryDb, SnapsRegistryDatabaseStruct)).not.toThrow();
+  });
+
+  it('has a only mandatory fields', () => {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const registryDb = {
+      verifiedSnaps: {
+        'npm:example-snap': {
+          id: 'npm:example-snap',
+          metadata: {
+            name: 'Example Snap',
+          },
+          versions: {
+            '0.1.0': {
+              checksum: 'A83r5/ZIcKeKw3An13HBeV4CAofj7jGK5hOStmHY6A0=',
+            },
+          },
+        },
+      },
+      blockedSnaps: [
+        {
+          id: 'npm:example-blocked-snap',
+          versionRange: '^0.1.0',
+        },
+        {
+          checksum: 'B3ar53ZIcKeKw3An3aqBeV4CAofj7jGK5hOAAxQY6A0=',
+        },
+      ],
+    };
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    expect(() => assert(registryDb, SnapsRegistryDatabaseStruct)).not.toThrow();
+  });
+
+  it('should throw when the metadata has an unexpected field', () => {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const registryDb = {
+      verifiedSnaps: {
+        'npm:example-snap': {
+          id: 'npm:example-snap',
+          metadata: {
+            name: 'Example Snap',
+            unexpected: 'field',
           },
           versions: {
             '0.1.0': {
@@ -38,6 +111,8 @@ describe('Snaps Registry', () => {
     };
     /* eslint-enable @typescript-eslint/naming-convention */
 
-    expect(() => assert(registryDb, SnapsRegistryDatabaseStruct)).not.toThrow();
+    expect(() => assert(registryDb, SnapsRegistryDatabaseStruct)).toThrow(
+      'At path: verifiedSnaps.npm:example-snap.metadata.unexpected -- Expected a value of type `never`, but received: `"field"`',
+    );
   });
 });

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -21,7 +21,7 @@ describe('Snaps Registry', () => {
             website: 'https://metamask.io',
             summary: 'Example Snap',
             description: 'Longer Example Snap description.',
-            reports: [
+            audits: [
               'https://metamask.io/example/report-1.pdf',
               'https://metamask.io/example/report-2.pdf',
             ],

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -7,4 +7,37 @@ describe('Snaps Registry', () => {
   it('has valid format', () => {
     expect(() => assert(registry, SnapsRegistryDatabaseStruct)).not.toThrow();
   });
+
+  it('has a valid account snap', () => {
+    /* eslint-disable @typescript-eslint/naming-convention */
+    const registryDb = {
+      verifiedSnaps: {
+        'npm:example-snap': {
+          id: 'npm:example-snap',
+          metadata: {
+            name: 'Example Snap',
+            type: 'account',
+            author: 'Example Author',
+            website: 'https://metamask.io',
+            summary: 'Example Snap',
+            description: 'Longer Example Snap description.',
+            reports: [
+              'https://metamask.io/example/report-1.pdf',
+              'https://metamask.io/example/report-2.pdf',
+            ],
+            tags: ['accounts', 'example'],
+          },
+          versions: {
+            '0.1.0': {
+              checksum: 'A83r5/ZIcKeKw3An13HBeV4CAofj7jGK5hOStmHY6A0=',
+            },
+          },
+        },
+      },
+      blockedSnaps: [],
+    };
+    /* eslint-enable @typescript-eslint/naming-convention */
+
+    expect(() => assert(registryDb, SnapsRegistryDatabaseStruct)).not.toThrow();
+  });
 });


### PR DESCRIPTION
The added metadata will be visible to users when they're adding a new snap account. All the newly introduced fields are optional, as they might not be necessary for other types of snaps.

Closes: MetaMask/accounts-planning/issues/21