### PR TITLE
Create invalidation for secondary CloudFront distribution after deployment

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -123,3 +123,4 @@ jobs:
         run: |
           aws s3 cp ./dist s3://${{ vars.AWS_BUCKET_NAME }}/latest --recursive --acl private
           aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CF_DISTRIBUTION_ID }} --paths "/latest/*"
+          aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CF_SECONDARY_DISTRIBUTION_ID }} --paths "/latest/*"


### PR DESCRIPTION
Now we create an invalidation for both CloudFront distributions.

`AWS_CF_SECONDARY_DISTRIBUTION_ID` will need to be added.