### PR TITLE
Add category enum to metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,9 @@ export const VerifiedSnapStruct = object({
     summary: optional(string()),
     description: optional(string()),
     audits: optional(array(AuditStruct)),
+    category: optional(
+      enums(['interoperability', 'notifications', 'transaction insights']),
+    ),
     tags: optional(array(string())),
     support: optional(string()),
     sourceCode: optional(string()),

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -38,6 +38,7 @@ describe('Snaps Registry', () => {
             ],
             support: 'https://metamask.io/example/support',
             sourceCode: 'https://metamask.io/example/source-code',
+            category: 'interoperability',
             tags: ['accounts', 'example'],
           },
           versions: {


### PR DESCRIPTION
This adds a new category field to the metadata, which can be set to one of the three categories at launch.