### PR TITLE
Republish directory after registry deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,7 @@ jobs:
     secrets:
       REGISTRY_PRIVATE_KEY: ${{ secrets.REGISTRY_PRIVATE_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      REPUBLISH_DIRECTORY_TOKEN: ${{ secrets.REPUBLISH_DIRECTORY_TOKEN }}
 
   is-release:
     # Filtering by `push` events ensures that we only release from the `main` branch, which is a

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -124,3 +124,20 @@ jobs:
           aws s3 cp ./dist s3://${{ vars.AWS_BUCKET_NAME }}/latest --recursive --acl private
           aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CF_DISTRIBUTION_ID }} --paths "/latest/*"
           aws cloudfront create-invalidation --distribution-id ${{ vars.AWS_CF_SECONDARY_DISTRIBUTION_ID }} --paths "/latest/*"
+
+  republish-directory:
+    name: Republish directory
+    needs:
+      - publish-registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.REPUBLISH_DIRECTORY_TOKEN }}
+          script: |
+            await github.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: 'snaps-directory',
+              workflow_id: 'republish-release.yml',
+              ref: 'main',
+            });

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -23,6 +23,8 @@ on:
         required: true
       SLACK_WEBHOOK_URL:
         required: false
+      REPUBLISH_DIRECTORY_TOKEN:
+        required: true
 
 jobs:
   check-updated:


### PR DESCRIPTION
The directory fetches from the registry. To ensure it's always up-to-date, we can automatically call the workflow to update the directory after the registry is deployed.