### PR TITLE
Tag Snaps publishers for releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       id-token: write # Required for requesting the OIDC JWT for cloud access token
     uses: ./.github/workflows/publish-registry.yml
     with:
-      slack-subteam: S042S7RE4AE # @metamask-npm-publishers
+      slack-subteam: S05RL9W7H54 # @metamask-snaps-publishers
     secrets:
       REGISTRY_PRIVATE_KEY: ${{ secrets.REGISTRY_PRIVATE_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -87,3 +87,4 @@ jobs:
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -6,7 +6,7 @@ on:
       slack-channel:
         required: false
         type: string
-        default: 'metamask-dev'
+        default: 'metamask-snaps'
       slack-icon-url:
         required: false
         type: string

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -50,7 +50,11 @@ jobs:
           key: ${{ github.sha }}
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v4
+        with:
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          subteam: S05RL9W7H54 # @metamask-snaps-publishers
+          channel: metamask-snaps
         env:
           SKIP_PREPACK: true
 
@@ -70,7 +74,7 @@ jobs:
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v2
+        uses: MetaMask/action-npm-publish@v4
         with:
           # This `NPM_TOKEN` needs to be manually set per-repository.
           # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,8 @@ on:
     secrets:
       NPM_TOKEN:
         required: true
+      SLACK_WEBHOOK_URL:
+        required: false
 
 jobs:
   publish-release:


### PR DESCRIPTION
Rather than tagging NPM publishers, we now tag Snaps publishers. Messages will be sent in the `metamask-snaps` channel.