### PR TITLE
Fix republishing script

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           github-token: ${{ secrets.REPUBLISH_DIRECTORY_TOKEN }}
           script: |
-            await github.repos.createDispatchEvent({
+            await github.rest.repos.createDispatchEvent({
               owner: context.repo.owner,
               repo: 'snaps-directory',
               workflow_id: 'republish-release.yml',


### PR DESCRIPTION
Fixes the republishing script by using `github.rest.*` instead of `github.*`