### PR TITLE
Remove unsafe or broken Discord links

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -111,9 +111,6 @@
           }
         ],
         "category": "transaction insights",
-        "support": {
-          "contact": "https://discord.com/invite/mvbtaJzXDP"
-        },
         "sourceCode": "https://github.com/wallet-guard/wallet-guard-snap"
       },
       "versions": {
@@ -596,7 +593,6 @@
           }
         ],
         "category": "interoperability",
-        "support": { "contact": "https://discord.gg/hYpHRjK" },
         "sourceCode": "https://github.com/Consensys/starknet-snap"
       },
       "versions": {
@@ -898,7 +894,6 @@
           }
         ],
         "category": "interoperability",
-        "support": { "contact": "https://discord.gg/M5xgNz7TTF" },
         "sourceCode": "https://github.com/blockchain-lab-um/masca"
       },
       "versions": {
@@ -954,7 +949,6 @@
           }
         ],
         "category": "transaction insights",
-        "support": { "contact": "https://discord.gg/RZ84RUNuNF" },
         "sourceCode": "https://github.com/AnChainAI/web3-security-snap"
       },
       "versions": {
@@ -982,7 +976,6 @@
         ],
         "category": "interoperability",
         "support": {
-          "contact": "https://discord.gg/Bzjm5MDXrU",
           "knowledgeBase": "https://rarimo.notion.site/RariMe-Knowledge-Doc-bf401216ae604f0faa490265f2ccd86f",
           "faq": "https://rarimo.notion.site/rariME-FAQ-19ebf31d8eaf4475aa8e64a1cc558800"
         },
@@ -1068,7 +1061,6 @@
           }
         ],
         "category": "interoperability",
-        "support": { "contact": "https://discord.gg/Wvhp9dWdSg" },
         "sourceCode": "https://github.com/EthSign/keychain-snap"
       },
       "versions": {
@@ -1095,9 +1087,6 @@
           }
         ],
         "category": "interoperability",
-        "support": {
-          "contact": "https://discord.com/invite/fMcZBH8ErM"
-        },
         "sourceCode": "https://github.com/drift-labs/snap-solana"
       },
       "versions": {

--- a/src/registry.json
+++ b/src/registry.json
@@ -111,6 +111,9 @@
           }
         ],
         "category": "transaction insights",
+        "support": {
+          "contact": "https://discord.com/invite/mvbtaJzXDP"
+        },
         "sourceCode": "https://github.com/wallet-guard/wallet-guard-snap"
       },
       "versions": {
@@ -593,6 +596,7 @@
           }
         ],
         "category": "interoperability",
+        "support": { "contact": "https://discord.gg/hYpHRjK" },
         "sourceCode": "https://github.com/Consensys/starknet-snap"
       },
       "versions": {
@@ -894,6 +898,7 @@
           }
         ],
         "category": "interoperability",
+        "support": { "contact": "https://discord.gg/M5xgNz7TTF" },
         "sourceCode": "https://github.com/blockchain-lab-um/masca"
       },
       "versions": {
@@ -949,6 +954,7 @@
           }
         ],
         "category": "transaction insights",
+        "support": { "contact": "https://discord.gg/RZ84RUNuNF" },
         "sourceCode": "https://github.com/AnChainAI/web3-security-snap"
       },
       "versions": {
@@ -976,6 +982,7 @@
         ],
         "category": "interoperability",
         "support": {
+          "contact": "https://discord.gg/Bzjm5MDXrU",
           "knowledgeBase": "https://rarimo.notion.site/RariMe-Knowledge-Doc-bf401216ae604f0faa490265f2ccd86f",
           "faq": "https://rarimo.notion.site/rariME-FAQ-19ebf31d8eaf4475aa8e64a1cc558800"
         },
@@ -1061,6 +1068,7 @@
           }
         ],
         "category": "interoperability",
+        "support": { "contact": "https://discord.gg/Wvhp9dWdSg" },
         "sourceCode": "https://github.com/EthSign/keychain-snap"
       },
       "versions": {
@@ -1087,6 +1095,9 @@
           }
         ],
         "category": "interoperability",
+        "support": {
+          "contact": "https://discord.com/invite/fMcZBH8ErM"
+        },
         "sourceCode": "https://github.com/drift-labs/snap-solana"
       },
       "versions": {

--- a/src/registry.json
+++ b/src/registry.json
@@ -513,9 +513,6 @@
           }
         ],
         "category": "interoperability",
-        "support": {
-          "contact": "https://discord.com/channels/484437221055922177/1145999516558958592"
-        },
         "sourceCode": "https://github.com/sotatek-dev/mina-snap"
       },
       "versions": {
@@ -542,7 +539,6 @@
           }
         ],
         "category": "interoperability",
-        "support": { "contact": "https://discord.gg/uDdgpzGT" },
         "sourceCode": "https://github.com/pianity/arsnap"
       },
       "versions": {
@@ -684,7 +680,6 @@
           }
         ],
         "category": "transaction insights",
-        "support": { "contact": "https://discord.gg/gN8YTfr9" },
         "sourceCode": "https://github.com/forta-network/metamask-snap"
       },
       "versions": {
@@ -877,9 +872,6 @@
           }
         ],
         "category": "interoperability",
-        "support": {
-          "contact": "https://discord.com/channels/720571334798737489/1111311863213473843/1111313848788602981"
-        },
         "sourceCode": "https://github.com/vegaprotocol/vega-snap"
       },
       "versions": {
@@ -1133,7 +1125,6 @@
         ],
         "category": "interoperability",
         "support": {
-          "contact": "https://discord.com/channels/831836269558235136/1149024081874784356",
           "knowledgeBase": "https://xmtp.org/docs/tutorials/other/xmtp-metamask-snap"
         },
         "sourceCode": "https://github.com/xmtp/snap"


### PR DESCRIPTION
Non-vanity Discord links are unsafe, as they can be claimed by other people. Discord channel links don't work, since they are not invites.