### PR TITLE
Remove websites for 4 Snaps

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -901,7 +901,6 @@
           "name": "Vega",
           "website": "https://vega.xyz/"
         },
-        "website": "https://vegaprotocol.eth.limo/",
         "summary": "Vega is an order book based derivatives DEX with no gas fees for trading. Deposit ERC20s and trade on the Vega appchain.",
         "description": "Vega is an order book based derivatives DEX with no gas fees for trading. Deposit ERC20s and trade on the Vega appchain. Vega markets are created and controlled by the Vega community and any trader operating as a market maker can commit to provide liquidity and share fee revenue.\n\nThe Vega Snap adds support for the Vega blockchain to MetaMask. You can access the Vega network through the Vega Metamask Snap.",
         "audits": [
@@ -1136,7 +1135,6 @@
           "name": "Drift Protocol",
           "website": "https://www.drift.trade/"
         },
-        "website": "https://www.drift.trade/",
         "summary": "An open-sourced Solana Snap that allows Metamask users to natively interact with Solana applications.",
         "description": "Connect by Drift allows MetaMask to seamlessly connect to Drift and function as a Solana wallet. Users of the Snap can connect to Drift, bridge their Ethereum assets to Solana, and trade on Drift all from within MetaMask.\n\nAfter installing the Snap, visit the website and click Launch App to try it. Please note: Drift may not be available in your region.",
         "audits": [

--- a/src/registry.json
+++ b/src/registry.json
@@ -845,7 +845,6 @@
           "name": "Rise Wallet",
           "website": "https://risewallet.io/"
         },
-        "website": "https://risewallet.io/",
         "summary": "Manage Aptos-based tokens and NFTs, swap, stake and connect to Aptos apps with MetaMask.",
         "description": "Manage Aptos-based tokens and NFTs, swap, stake and connect to Aptos apps with MetaMask. Website coming soon.",
         "audits": [
@@ -874,7 +873,6 @@
           "name": "Elli Wallet",
           "website": "https://elliwallet.com/"
         },
-        "website": "https://elliwallet.com/",
         "summary": "Manage Sui-based tokens and NFTs, stake and connect to Sui apps with MetaMask.",
         "description": "Manage Sui-based tokens and NFTs, stake and connect to Sui apps with MetaMask. Website coming soon.",
         "audits": [


### PR DESCRIPTION
This temporarily removes some websites that do not yet support the associated Snap. 

They will be added again when they are ready. 
