### PR TITLE
Bump metamask/networkacess-example-snap version

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -431,6 +431,9 @@
         },
         "0.38.1-flask.1": {
           "checksum": "YXxtxjP6SbPiDHzskryvh0QA6Hvv/FurI+GwNN8WF0U="
+        },
+        "0.38.2-flask.1": {
+          "checksum": "gietRn5VTciRfESWtWnTLKykNCZbTuIY7sRFhyTYkJI="
         }
       }
     },


### PR DESCRIPTION
bumps network access example snap version to 0.38.2-flask.1
