### PR TITLE
[Update Snap] Starknet version to 2.2.0

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1321,8 +1321,8 @@
         "sourceCode": "https://github.com/Consensys/starknet-snap"
       },
       "versions": {
-        "2.1.0": {
-          "checksum": "9HHio79u5s9b9e5isxf1dNZmdQ7JhPu/mC+Mf6IfzaE="
+        "2.2.0": {
+          "checksum": "+VwOFJaGNMcEVuIMh+hlc5DCpqPxwbflYvfVdhY8hT0="
         }
       }
     },


### PR DESCRIPTION
Fixes issue #200.
Bumps registry to show StarkNet's new 2.2.0 version.