### PR TITLE
Correct Filecoin contact email

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1479,7 +1479,7 @@
         ],
         "category": "interoperability",
         "support": {
-          "contact": "filsnap-support@protocol.ai"
+          "contact": "mailto:filecoin-snap@fil.org"
         },
         "sourceCode": "https://github.com/filecoin-project/filsnap/"
       },


### PR DESCRIPTION
Fixes the contact email for Filecoin Wallet to be `mailto:filecoin-snap@fil.org`