### PR TITLE
Update Masca 1.1.0

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1040,6 +1040,9 @@
         "sourceCode": "https://github.com/blockchain-lab-um/masca"
       },
       "versions": {
+        "1.1.0": {
+          "checksum": "lvNJQRx0yBScxfNkwkCnAtiRKSDkCkDlp3uMVBZXF7A="
+        },
         "1.0.0": {
           "checksum": "nVKFpAn6RCNMM8UOH344F+tQUP6pxGjzisRXGBYf550="
         }


### PR DESCRIPTION
This PR adds a new version of Masca Snap (v1.1.0).

Changes in the new version can be found here: https://hackmd.io/eOilSHWdS7uylpdHBkxN3A