### PR TITLE
Put QuickIntel in correct category

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1578,7 +1578,7 @@
             "report": "https://github.com/Quick-Intel/quickintel-snap/blob/main/VAR_quickintel_snap.pdf"
           }
         ],
-        "category": "interoperability",
+        "category": "transaction insights",
         "support": {
           "contact": "https://discord.gg/quicki",
           "faq": "https://docs.quickintel.io/metamask-snap/faq",


### PR DESCRIPTION
This assigns Quick Intel to the correct category Transaction Insights
