### PR TITLE
Use `noble-hashes` and `noble-curves`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   },
   "dependencies": {
     "@metamask/utils": "^8.1.0",
+    "@noble/curves": "^1.2.0",
     "@noble/hashes": "^1.3.2",
-    "@noble/secp256k1": "^1.7.1",
     "superstruct": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@metamask/utils": "^8.1.0",
+    "@noble/hashes": "^1.3.2",
     "@noble/secp256k1": "^1.7.1",
     "superstruct": "^1.0.3"
   },
@@ -43,7 +44,6 @@
     "@metamask/snaps-controllers": "^3.4.0",
     "@metamask/snaps-utils": "^5.0.0",
     "@noble/curves": "^1.2.0",
-    "@noble/hashes": "^1.3.2",
     "@types/jest": "^28.1.6",
     "@types/node": "^17.0.23",
     "@typescript-eslint/eslint-plugin": "^5.43.0",

--- a/scripts/create-key.ts
+++ b/scripts/create-key.ts
@@ -1,5 +1,5 @@
 import { bytesToHex, hasProperty } from '@metamask/utils';
-import * as secp256k1 from '@noble/secp256k1';
+import { secp256k1 } from '@noble/curves/secp256k1';
 import assert from 'assert';
 import * as dotenv from 'dotenv';
 import fs from 'fs/promises';

--- a/scripts/verify-registry.ts
+++ b/scripts/verify-registry.ts
@@ -56,7 +56,7 @@ async function main() {
   assertStruct(signature, SignatureStruct);
   const registry = await fs.readFile(registryPath, 'utf-8');
 
-  const isValid = await verify({ registry, signature, publicKey });
+  const isValid = verify({ registry, signature, publicKey });
   if (!isValid) {
     console.error('Signature is invalid.');
     // eslint-disable-next-line n/no-process-exit

--- a/src/verify.test.ts
+++ b/src/verify.test.ts
@@ -13,7 +13,7 @@ const MOCK_SIGNATURE = {
 describe('verify', () => {
   it('verifies a valid signature', async () => {
     expect(
-      await verify({
+      verify({
         registry: MOCK_REGISTRY,
         signature: MOCK_SIGNATURE,
         publicKey: MOCK_PUBLIC_KEY,
@@ -23,7 +23,7 @@ describe('verify', () => {
 
   it('rejects an invalid signature', async () => {
     expect(
-      await verify({
+      verify({
         registry: MOCK_REGISTRY,
         signature: {
           ...MOCK_SIGNATURE,
@@ -36,7 +36,7 @@ describe('verify', () => {
   });
 
   it('throws an error if the signature format is invalid', async () => {
-    await expect(
+    expect(() =>
       verify({
         registry: MOCK_REGISTRY,
         signature: {
@@ -45,7 +45,7 @@ describe('verify', () => {
         },
         publicKey: MOCK_PUBLIC_KEY,
       }),
-    ).rejects.toThrow(
+    ).toThrow(
       'Invalid signature object: At path: signature -- Expected a string, but received: undefined.',
     );
   });

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 import type { Hex } from '@metamask/utils';
 import {
   remove0x,

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -37,11 +37,11 @@ type VerifyArgs = {
  * the signature to.
  * @returns Whether the signature is valid.
  */
-export async function verify({
+export function verify({
   registry,
   signature,
   publicKey,
-}: VerifyArgs): Promise<boolean> {
+}: VerifyArgs): boolean {
   assertStruct(signature, SignatureStruct, 'Invalid signature object');
 
   const publicKeyBytes = hexToBytes(publicKey);

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -5,11 +5,8 @@ import {
   assertStruct,
   hexToBytes,
 } from '@metamask/utils';
+import { secp256k1 } from '@noble/curves/secp256k1';
 import { sha256 } from '@noble/hashes/sha256';
-import {
-  verify as nobleVerify,
-  Signature as NobleSignature,
-} from '@noble/secp256k1';
 import type { Infer } from 'superstruct';
 import { literal, object, pattern, string } from 'superstruct';
 
@@ -46,8 +43,8 @@ export function verify({
 
   const publicKeyBytes = hexToBytes(publicKey);
 
-  return nobleVerify(
-    NobleSignature.fromHex(remove0x(signature.signature)),
+  return secp256k1.verify(
+    remove0x(signature.signature),
     sha256(stringToBytes(registry)),
     publicKeyBytes,
   );

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-globals */
 import type { Hex } from '@metamask/utils';
 import {
   remove0x,
@@ -5,9 +6,9 @@ import {
   assertStruct,
   hexToBytes,
 } from '@metamask/utils';
+import { sha256 } from '@noble/hashes/sha256';
 import {
   verify as nobleVerify,
-  utils,
   Signature as NobleSignature,
 } from '@noble/secp256k1';
 import type { Infer } from 'superstruct';
@@ -48,7 +49,7 @@ export async function verify({
 
   return nobleVerify(
     NobleSignature.fromHex(remove0x(signature.signature)),
-    await utils.sha256(stringToBytes(registry)),
+    sha256(stringToBytes(registry)),
     publicKeyBytes,
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1182,7 +1182,6 @@ __metadata:
     "@metamask/utils": ^8.1.0
     "@noble/curves": ^1.2.0
     "@noble/hashes": ^1.3.2
-    "@noble/secp256k1": ^1.7.1
     "@types/jest": ^28.1.6
     "@types/node": ^17.0.23
     "@typescript-eslint/eslint-plugin": ^5.43.0
@@ -1351,7 +1350,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/secp256k1@npm:^1.5.5, @noble/secp256k1@npm:^1.7.1":
+"@noble/secp256k1@npm:^1.5.5":
   version: 1.7.1
   resolution: "@noble/secp256k1@npm:1.7.1"
   checksum: d2301f1f7690368d8409a3152450458f27e54df47e3f917292de3de82c298770890c2de7c967d237eff9c95b70af485389a9695f73eb05a43e2bd562d18b18cb


### PR DESCRIPTION
Use `noble-hashes` for SHA256 instead of the utility function from `@noble/secp256k1` since the existing code is not compatible with React Native. Use `noble-curves` as that still supports CommonJS.