### PR TITLE
Add additional source code field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export const VerifiedSnapStruct = object({
     privateCode: optional(boolean()),
     privacyPolicy: optional(string()),
     termsOfUse: optional(string()),
+    additionalSourceCode: optional(array(string())),
   }),
   versions: record(VersionStruct, VerifiedSnapVersionStruct),
 });

--- a/src/registry.test.ts
+++ b/src/registry.test.ts
@@ -48,6 +48,10 @@ describe('Snaps Registry', () => {
             tags: ['accounts', 'example'],
             privacyPolicy: 'https://metamask.io/example/privacy',
             privateCode: true,
+            additionalSourceCode: [
+              'https://metamask.io/example/source-code2',
+              'https://metamask.io/example/source-code3',
+            ],
           },
           versions: {
             ['0.1.0' as SemVerVersion]: {


### PR DESCRIPTION
Adds a metadata field for additional source code. This can be used for open source parts of the snap that are in addition to the main snap source code.

Fixes https://github.com/MetaMask/snaps-registry/issues/395