### PR TITLE
Remove lookup example snap from allowlist

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -2038,18 +2038,6 @@
           "checksum": "0LYVuy8axHCCii9kBjsl6e0o/NNGe3d2hFysfOJzDYc="
         }
       }
-    },
-    "npm:@metamask/name-lookup-example-snap": {
-      "id": "npm:@metamask/name-lookup-example-snap",
-      "metadata": {
-        "name": "Name Lookup Example Snap",
-        "hidden": true
-      },
-      "versions": {
-        "2.1.0": {
-          "checksum": "Sbu/MyQ6Mrxr6/4DDjd6SVjESJ2jrWASZSHc5JukBBo="
-        }
-      }
     }
   },
   "blockedSnaps": [


### PR DESCRIPTION
The lookup example snap was prematurely added to the allowlist and is causing build errors in the directory.

This snap can be re-added once the name lookup API is stable and requires allowlisting.
