### PR TITLE
Revert "Update Starknet to 2.5.2 (#469)"

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1468,8 +1468,8 @@
         "sourceCode": "https://github.com/Consensys/starknet-snap"
       },
       "versions": {
-        "2.5.2": {
-          "checksum": "qYquBTPQKr41UHZyNu9QkMjMjnD45cYGyqvNAx1GKg4="
+        "2.4.0": {
+          "checksum": "lfxsHs6C6buodVo0zVJakNAHgIXAGkHyVTL12Rw0xdw="
         }
       }
     },


### PR DESCRIPTION
This reverts commit c65e1506563c69bd694509ef42b1a0e5c98def35.