### PR TITLE
Bump `@consensys/starknet-snap` to `2.5.2`

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1462,14 +1462,14 @@
           }
         ],
         "category": "interoperability",
+        "sourceCode": "https://github.com/Consensys/starknet-snap",
         "support": {
           "contact": "https://discord.gg/hYpHRjK"
-        },
-        "sourceCode": "https://github.com/Consensys/starknet-snap"
+        }
       },
       "versions": {
-        "2.4.0": {
-          "checksum": "lfxsHs6C6buodVo0zVJakNAHgIXAGkHyVTL12Rw0xdw="
+        "2.5.2": {
+          "checksum": "qYquBTPQKr41UHZyNu9QkMjMjnD45cYGyqvNAx1GKg4="
         }
       }
     },


### PR DESCRIPTION
See #468. This redoes #469 after having to revert it.