### PR TITLE
Revert "Bump `@consensys/starknet-snap` to `2.5.2` (#474)"

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1462,14 +1462,14 @@
           }
         ],
         "category": "interoperability",
-        "sourceCode": "https://github.com/Consensys/starknet-snap",
         "support": {
           "contact": "https://discord.gg/hYpHRjK"
-        }
+        },
+        "sourceCode": "https://github.com/Consensys/starknet-snap"
       },
       "versions": {
-        "2.5.2": {
-          "checksum": "qYquBTPQKr41UHZyNu9QkMjMjnD45cYGyqvNAx1GKg4="
+        "2.4.0": {
+          "checksum": "lfxsHs6C6buodVo0zVJakNAHgIXAGkHyVTL12Rw0xdw="
         }
       }
     },


### PR DESCRIPTION
This reverts commit 4712b37636987cb05739973c8e04f497106fa900.