### PR TITLE
Bump `@metamask/superstruct` to `^3.1.0`, `@metamask/utils` to `^9.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "verify-snaps": "ts-node scripts/verify-snaps.ts"
   },
   "dependencies": {
-    "@metamask/superstruct": "^3.0.0",
-    "@metamask/utils": "^8.5.0",
+    "@metamask/superstruct": "^3.1.0",
+    "@metamask/utils": "^9.0.0",
     "@noble/curves": "^1.2.0",
     "@noble/hashes": "^1.3.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1254,8 +1254,8 @@ __metadata:
     "@metamask/snaps-controllers": ^8.2.0
     "@metamask/snaps-sdk": ^4.3.0
     "@metamask/snaps-utils": ^7.4.0
-    "@metamask/superstruct": ^3.0.0
-    "@metamask/utils": ^8.5.0
+    "@metamask/superstruct": ^3.1.0
+    "@metamask/utils": ^9.0.0
     "@noble/curves": ^1.2.0
     "@noble/hashes": ^1.3.2
     "@types/jest": ^28.1.6
@@ -1352,7 +1352,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.3.0, @metamask/utils@npm:^8.5.0":
+"@metamask/superstruct@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@metamask/superstruct@npm:3.1.0"
+  checksum: 00e4d0c0aae8b25ccc1885c1db0bb4ed1590010570140c255e4deee3bf8a10c859c8fce5e475b4ae09c8a56316207af87585b91f7f5a5c028d668ccd111f19e3
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^8.1.0, @metamask/utils@npm:^8.3.0":
   version: 8.5.0
   resolution: "@metamask/utils@npm:8.5.0"
   dependencies:
@@ -1366,6 +1373,23 @@ __metadata:
     semver: ^7.5.4
     uuid: ^9.0.1
   checksum: e8eac1c796c3f6b623be3c2736e8682248620f666b180f5c12ce56ee09587d4e28b6811862139a05c7a1bec91415f10ccf0516f3cdf342f88b0189d2a057c24b
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/utils@npm:9.0.0"
+  dependencies:
+    "@ethereumjs/tx": ^4.2.0
+    "@metamask/superstruct": ^3.1.0
+    "@noble/hashes": ^1.3.1
+    "@scure/base": ^1.1.3
+    "@types/debug": ^4.1.7
+    debug: ^4.3.4
+    pony-cause: ^2.1.10
+    semver: ^7.5.4
+    uuid: ^9.0.1
+  checksum: 5dcb9d47c4768c33d451cc74c83207726c68b1340be1d091ca44105564f0ba0703026d357de7996de4459ac41cd420a0eb1f06db32f5ebbeeee581393f45fd44
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- See https://github.com/MetaMask/snaps/pull/2445
- See https://github.com/MetaMask/core/pull/3645