### PR TITLE
Use `metamask-snaps-deployments` channel for deployment messages

### DIFF
--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -6,7 +6,7 @@ on:
       slack-channel:
         required: false
         type: string
-        default: 'metamask-snaps'
+        default: 'metamask-snaps-deployments'
       slack-icon-url:
         required: false
         type: string

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S05RL9W7H54 # @metamask-snaps-publishers
-          channel: metamask-snaps
+          channel: metamask-snaps-deployments
         env:
           SKIP_PREPACK: true
 


### PR DESCRIPTION
This updates the publish workflows to send a Slack message in `metamask-snaps-deployments`.