### PR TITLE
Update SSK versions

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -3311,6 +3311,9 @@
         },
         "1.1.2": {
           "checksum": "euGuIXw57Wfb1sBktAhCRMd6DY8Xl07GOXOg88NF/Bk="
+        },
+        "1.1.6": {
+          "checksum": "P2BbaJn6jb7+ecBF6mJJnheQ4j8dtEZ8O4FLqLv8e8M="
         }
       }
     },


### PR DESCRIPTION
We need to whitelist the new v1.1.6 which now uses packages from the new [accounts monorepo](https://github.com/MetaMask/accounts) and we'd like to use this one in extension E2E tests.

Thanks!
