### PR TITLE
Update missing mailto: in some snaps contact metadata

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1334,7 +1334,7 @@
         ],
         "category": "interoperability",
         "support": {
-          "contact": "support@qtum.info",
+          "contact": "mailto:support@qtum.info",
           "faq": "https://github.com/qtumproject/qtum-extension-wallet?tab=readme-ov-file#qtum-wallet-faq",
           "knowledgeBase": "https://github.com/qtumproject/qtum-extension-wallet?tab=readme-ov-file#qtum-wallet-knowledge-doc"
         },
@@ -2078,7 +2078,7 @@
         ],
         "category": "interoperability",
         "support": {
-          "contact": "donna@aeternity.com"
+          "contact": "mailto:donna@aeternity.com"
         },
         "sourceCode": "https://github.com/4-point-0/aeternity-snap"
       },
@@ -3612,7 +3612,7 @@
         "support": {
           "knowledgeBase": "https://github.com/TokenScript-Framework/token-kit/blob/main/packages/tapp-snap/README.md",
           "faq": "https://github.com/TokenScript-Framework/token-kit/blob/main/packages/tapp-snap/FAQ.md",
-          "contact": "v@smarttokenlabs.com"
+          "contact": "mailto:v@smarttokenlabs.com"
         },
         "sourceCode": "https://github.com/TokenScript-Framework/token-kit/tree/main/packages/tapp-snap",
         "screenshots": [


### PR DESCRIPTION
### PR Description

#### What is the current state of things and why does it need to change?
The contact fields for some snaps in the `registry.json` file currently contain email addresses without the `mailto:` prefix. This could cause inconsistencies or issues where the correct format (with `mailto:`) is expected.

#### What is the solution your changes offer and how does it work?
This PR updates the `contact` field for the affected snaps to include the `mailto:` prefix, ensuring all email addresses are in the proper format for links and interactions. Specifically, three snaps have been updated:

- **Qtum Snap**: Changed `"support@qtum.info"` to `"mailto:support@qtum.info"`.
- **Aeternity Snap**: Changed `"donna@aeternity.com"` to `"mailto:donna@aeternity.com"`.
- **TokenScript Snap**: Changed `"v@smarttokenlabs.com"` to `"mailto:v@smarttokenlabs.com"`.

#### Are there any issues or other links reviewers should consult to understand this pull request better?
No related issues were filed, but these changes are necessary for consistent contact formatting across snaps.