### PR TITLE
Bump `npm:@metamask/ethereum-provider-example-snap` to `2.3.0`

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -581,6 +581,9 @@
         },
         "2.2.1": {
           "checksum": "8f7Fo6y40+L0x+KHkDCq2wjEMrkTL+L6e2NSNBZYVLA="
+        },
+        "2.3.0": {
+          "checksum": "7i20r0cCFwMESzBcTMgRNOt82AjwHneiM6LtD7vXCGw="
         }
       }
     },


### PR DESCRIPTION
This adds version `2.3.0` of the Ethereum provider example.