### PR TITLE
Update example Snaps

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -428,6 +428,18 @@
         }
       }
     },
+    "npm:@metamask/background-events-example-snap": {
+      "id": "npm:@metamask/background-events-example-snap",
+      "metadata": {
+        "name": "Background Events Example Snap",
+        "hidden": true
+      },
+      "versions": {
+        "1.0.0": {
+          "checksum": "hErp73GYyo7PY+AZUPmuL94+EgeKfPJeUVq2UURgfQU="
+        }
+      }
+    },
     "npm:@metamask/cronjob-example-snap": {
       "id": "npm:@metamask/cronjob-example-snap",
       "metadata": {
@@ -584,6 +596,9 @@
         },
         "2.3.0": {
           "checksum": "7i20r0cCFwMESzBcTMgRNOt82AjwHneiM6LtD7vXCGw="
+        },
+        "2.4.0": {
+          "checksum": "I4+h3lL7U70t4ZHZagAuECK8sYOKcsiqowBM52gLd/8="
         }
       }
     },


### PR DESCRIPTION
This adds `@metamask/background-events-example-snap@1.0.0` (first release), and `@metamask/ethereum-provider-example-snap@2.4.0`.