### PR TITLE
chore: Bump lifecycle hooks example

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1461,6 +1461,9 @@
         },
         "2.2.0": {
           "checksum": "5tlM5E71Fbeid7I3F0oQURWL7/+0620wplybtklBCHQ="
+        },
+        "2.3.0": {
+          "checksum": "s2CUQ+L8GuVTLahEgApRNp8gEdH3Fv7TAvu+9+Mmx54="
         }
       }
     },


### PR DESCRIPTION
This adds version 2.3.0 of the lifecycle hooks example to the registry.