### PR TITLE
Update Galactica ZK Vault

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -2798,23 +2798,8 @@
         ]
       },
       "versions": {
-        "1.0.1": {
-          "checksum": "QNmQtBBfoCMJmJaF96QzH44s2obm3k2Ct0t3Lje0Bog="
-        },
-        "0.8.5": {
-          "checksum": "Qf2AILs2sOJggiV2xWdLfEuS/wkyaY/YeysZ6bqAMf0="
-        },
-        "0.8.4": {
-          "checksum": "SoaG/3rijtC5asZQ1O2CIscHJ2Eqb9kW4wIqEAhUue8="
-        },
-        "0.8.3": {
-          "checksum": "cGKt6nNCMN6tJAyXdCH/6Pw2J9l2IvsY2uTjsIJiitk="
-        },
-        "0.7.3": {
-          "checksum": "tKTO2/Dru/fEinbw1Ag63I+wLT2aE/XX4XMHwzfS3ow="
-        },
-        "0.6.1": {
-          "checksum": "HbPS0L0HN5om/cXvYdWMoGn+hGfeS2dPqJ113OTjNH8="
+        "1.0.2": {
+          "checksum": "Q2AaPpeWKRY9bVboSZ03WfRTUb3oRDtebqzX89LbiX4="
         }
       }
     },

--- a/src/registry.json
+++ b/src/registry.json
@@ -2798,6 +2798,9 @@
         ]
       },
       "versions": {
+        "1.0.1": {
+          "checksum": "QNmQtBBfoCMJmJaF96QzH44s2obm3k2Ct0t3Lje0Bog="
+        },
         "0.8.5": {
           "checksum": "Qf2AILs2sOJggiV2xWdLfEuS/wkyaY/YeysZ6bqAMf0="
         },


### PR DESCRIPTION
This closes #1346

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Galactica ZK Vault snap to version 1.0.2 and removes older versions from the registry.
> 
> - **Registry**:
>   - **Galactica ZK Vault** (`npm:@galactica-net/snap`):
>     - Add `1.0.2` with checksum.
>     - Remove `0.8.5`, `0.8.4`, `0.8.3`, `0.7.3`, `0.6.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26b14e66a02c749eb5b30312c32de4cf82e9dcae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->