### PR TITLE
Add `snap-simple-keyring` v2.0.0 to the allowlist

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -4104,6 +4104,9 @@
         },
         "1.1.6": {
           "checksum": "P2BbaJn6jb7+ecBF6mJJnheQ4j8dtEZ8O4FLqLv8e8M="
+        },
+        "2.0.0": {
+          "checksum": "bFMN5hlkguPBHNaiusJPWZh6yhFnTShcY1mu0Ko5YMM="
         }
       }
     },


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
Context:

The update to 2.0.0 doesn't change anything on the snap-simple-keyring. It's a major update, because we have made the snap-simple-keyring-site publishable, in order to use it in our e2e as a local server.

See more here:
- https://github.com/MetaMask/snap-simple-keyring/pull/163
- https://github.com/MetaMask/metamask-extension/pull/36557 

