### PR TITLE
chore: Bump interactive UI example Snap

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -4193,6 +4193,9 @@
         "hidden": true
       },
       "versions": {
+        "2.5.0": {
+          "checksum": "BkV0BL502gxdAXneGE5PZkAvETCUkHlItX3bka/LznA="
+        },
         "2.4.0": {
           "checksum": "I+kz7pvB5o7oyC/2z5LnURYG7TrTHR9+oWueIcsuDyA="
         },


### PR DESCRIPTION
Include latest version of interactive UI example Snap on the registry for testing purposes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds version `2.5.0` (with checksum) for `npm:@metamask/interactive-ui-example-snap` in `src/registry.json`.
> 
> - **Registry**:
>   - Update `src/registry.json` to include `npm:@metamask/interactive-ui-example-snap` version `2.5.0` with its checksum.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3984841298cececf185986650319b90cb38c8b31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->