### PR TITLE
chore!: Drop support for Node 18

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -96,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x]
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "packageManager": "yarn@3.2.1",
   "engines": {
-    "node": "^18.16 || >=20"
+    "node": "^20 || >=22"
   },
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Drop support for Node 18 which is EOL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove Node 18 from supported/runtime matrices and require Node 20+ (20/22) in CI and package engines.
> 
> - **CI**:
>   - Update matrices in `.github/workflows/build-lint-test.yml` to drop `18.x`; run on `20.x` and `22.x` for `prepare`, `test`, and `compatibility-test`.
> - **Package**:
>   - Change `engines.node` in `package.json` from `^18.16 || >=20` to `^20 || >=22`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b9dea6e964b814c06534bd68f8e7be650c0832. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->