### PR TITLE
Revert "4.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0]
-### Changed
-- **BREAKING:** Use async crypto digest API for hashing ([#1400](https://github.com/MetaMask/snaps-registry/pull/1400))
-  - The exported `verify` function is now async.
-- **BREAKING:** Drop support for Node 18 ([#1401](https://github.com/MetaMask/snaps-registry/pull/1401))
-
 ## [3.3.0]
 ### Added
 - Allow specifying `clientVersions` ([#1388](https://github.com/MetaMask/snaps-registry/pull/1388))
@@ -104,8 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/MetaMask/snaps-registry/compare/v4.0.0...HEAD
-[4.0.0]: https://github.com/MetaMask/snaps-registry/compare/v3.3.0...v4.0.0
+[Unreleased]: https://github.com/MetaMask/snaps-registry/compare/v3.3.0...HEAD
 [3.3.0]: https://github.com/MetaMask/snaps-registry/compare/v3.2.3...v3.3.0
 [3.2.3]: https://github.com/MetaMask/snaps-registry/compare/v3.2.2...v3.2.3
 [3.2.2]: https://github.com/MetaMask/snaps-registry/compare/v3.2.1...v3.2.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/snaps-registry",
-  "version": "4.0.0",
+  "version": "3.3.0",
   "description": "A registry containing metadata about verified and blocked Snaps.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Reverts MetaMask/snaps-registry#1402

Release failed due to out of date yarn.lock, which apparently isn't checked in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the 4.0.0 release by downgrading to 3.3.0 and removing 4.0.0 changelog entries.
> 
> - **Release rollback**:
>   - Set `package.json` version back to `3.3.0`.
>   - Remove `4.0.0` section from `CHANGELOG.md` and update `[Unreleased]` compare link to start from `v3.3.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60d8f855c2fb88c485623b48ab7e4b4c5ac48856. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->