### PR TITLE
chore: Bump example Snaps

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -4186,6 +4186,9 @@
         },
         "1.1.1": {
           "checksum": "kbuZtLjZiY9+HOtc7DIpuGUjMes2id67dES3Ze/Z3dY="
+        },
+        "1.2.0": {
+          "checksum": "7Wzg0p7PiQ5Q2U8VqAbkwj+Ep0jbETFeu7E/oe9DgUo="
         }
       }
     },


### PR DESCRIPTION
Bump Ethereum provider and images example Snaps to latest version for E2E purposes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Snap registry to reference the latest Ethereum provider example Snap version.
> 
> - Adds `3.0.0` entry with checksum in `src/registry.json` for the Ethereum provider example Snap
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b504d6697e4fed0b22e4b5aa0804262835df9e43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->