### PR TITLE
Add Tron wallet snap metadata to registry

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -5478,6 +5478,18 @@
           "checksum": "YA+qmj7Q3fB1UcO5A2d3UekTzVHuY/YuMhrmfynHg20="
         }
       }
+    },
+    "npm:@metamask/tron-wallet-snap": {
+      "id": "npm:@metamask/tron-wallet-snap",
+      "metadata": {
+        "name": "Tron",
+        "hidden": true
+      },
+      "versions": {
+        "1.21.1": {
+          "checksum": "z4+3fdZhAyzb6R94sNJYeTuW/t7H48Qyuc3t72eraXw="
+        }
+      }
     }
   },
   "blockedSnaps": [


### PR DESCRIPTION
OTA rollout of the new Tron snap with bug fixes and ensuring dApp connectivity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata-only addition to the snap registry; low risk aside from correctness of the version/checksum values.
> 
> **Overview**
> Adds a new verified snap entry `npm:@metamask/tron-wallet-snap` to `src/registry.json`, marked as hidden and pinned to version `1.21.1` with its checksum.
> 
> No other registry entries or blocklist rules are changed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f994246cdc39d126d8c2a133478e121d70570063. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->