### PR TITLE
chore: bump @metamask/tron-wallet-snap to `1.22.1`

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -5491,6 +5491,9 @@
         "hidden": true
       },
       "versions": {
+        "1.22.1": {
+          "checksum": "7Lq5bCUwPBKAiNcLQnCK1ucdLJxXIwQe6jSxH953iqU="
+        },
         "1.21.1": {
           "checksum": "z4+3fdZhAyzb6R94sNJYeTuW/t7H48Qyuc3t72eraXw="
         }


### PR DESCRIPTION
Closes [NEB-555](https://consensyssoftware.atlassian.net/browse/NEB-555) by releasing the latest Tron snap OTA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk registry update that only adds a new version entry for a single snap; main risk is an incorrect checksum/version causing deployment or verification issues.
> 
> **Overview**
> Updates `src/registry.json` to include `npm:@metamask/tron-wallet-snap` version `1.22.1` with its checksum, enabling that snap release to be served/verified via the registry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4abfec8dd1fb2f7edc25000512100efbcc073e76. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->