### PR TITLE
chore: Bump name lookup example Snap

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -4808,6 +4808,9 @@
         },
         "3.1.1": {
           "checksum": "xk7O5itVsuV3Dfldq3rI3WgggHa3z7HX7e17jzheE8w="
+        },
+        "3.1.2": {
+          "checksum": "SRmLTMVKJvWHyVH5H3HhvMz0iQOWn4St4/9xX8Sv1EM="
         }
       }
     },


### PR DESCRIPTION
Bump name lookup example Snap for E2E.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk registry-only change; the main impact is that consumers will fetch the new `@metamask/name-lookup-example-snap` artifact, so failures would be limited to Snap installation/CI that relies on this version.
> 
> **Overview**
> Updates `src/registry.json` to register `npm:@metamask/name-lookup-example-snap` version `3.1.2` by adding its checksum, effectively bumping the example Snap used for E2E/install flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aeeeeedfdfb26928c17ed05dcc42479f3a45443. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->