### PR TITLE
ci: Add merge queue support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,11 +66,11 @@ jobs:
       - analyse-code
       - build-lint-test
     outputs:
-      PASSED: ${{ steps.set-output.outputs.PASSED }}
+      passed: ${{ steps.set-output.outputs.passed }}
     steps:
-      - name: Set PASSED output
+      - name: Set passed output
         id: set-output
-        run: echo "PASSED=true" >> "$GITHUB_OUTPUT"
+        run: echo "passed=true" >> "$GITHUB_OUTPUT"
 
   all-jobs-pass:
     name: All jobs pass

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
       - all-jobs-completed
       - check-skip-merge-queue
     env:
-      PASSED: ${{ needs.all-jobs-complete.outputs.passed == 'true' || needs.check-skip-merge-queue.outputs.skip-merge-queue == 'true' }}
+      PASSED: ${{ needs.all-jobs-completed.outputs.passed == 'true' || needs.check-skip-merge-queue.outputs.skip-merge-queue == 'true' }}
     steps:
       - name: Check that all jobs have passed
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,10 +6,25 @@ on:
       - main
       - test
   pull_request:
+  merge_group:
 
 jobs:
+  check-skip-merge-queue:
+    name: Check if pull request can skip merge queue
+    runs-on: ubuntu-latest
+    outputs:
+      skip-merge-queue: ${{ steps.check-skip-merge-queue.outputs.up-to-date }}
+    steps:
+      - name: Check pull request merge queue status
+        id: check-skip-merge-queue
+        if: github.event_name == 'merge_group'
+        uses: MetaMask/github-tools/.github/actions/check-skip-merge-queue@v1
+
   check-workflows:
     name: Check workflows
+    needs:
+      - check-skip-merge-queue
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
@@ -38,6 +53,9 @@ jobs:
 
   build-lint-test:
     name: Build, lint, and test
+    needs:
+      - check-skip-merge-queue
+    if: github.event_name != 'merge_group' || needs.check-skip-merge-queue.outputs.skip-merge-queue != 'true'
     uses: ./.github/workflows/build-lint-test.yml
 
   all-jobs-completed:
@@ -58,12 +76,15 @@ jobs:
     name: All jobs pass
     if: ${{ always() }}
     runs-on: ubuntu-latest
-    needs: all-jobs-completed
+    needs:
+      - all-jobs-completed
+      - check-skip-merge-queue
+    env:
+      PASSED: ${{ needs.all-jobs-complete.outputs.passed == 'true' || needs.check-skip-merge-queue.outputs.skip-merge-queue == 'true' }}
     steps:
       - name: Check that all jobs have passed
         run: |
-          passed="${{ needs.all-jobs-completed.outputs.PASSED }}"
-          if [[ $passed != "true" ]]; then
+          if [[ "$PASSED" != "true" ]]; then
             exit 1
           fi
 


### PR DESCRIPTION
This adds the `merge_group` trigger and adds some logic for skipping the merge queue if a pull request is up-to-date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI orchestration for `merge_group` events and introduces conditional skipping logic; misconfiguration could inadvertently bypass required checks or affect merge/publish gating.
> 
> **Overview**
> Adds `merge_group` as a workflow trigger and introduces a new `check-skip-merge-queue` job to determine whether merge-queue runs can be skipped when the PR is already up to date.
> 
> Updates `check-workflows` and `build-lint-test` to depend on this check and *not run* when skipping is allowed, and adjusts the final gate (`all-jobs-pass`) to treat the workflow as passed when either all jobs passed or the merge-queue skip condition is true (including renaming the completion output to `passed`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6479292d6134ee5a213bfffe2a5893a0095ce741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->