### PR TITLE
Add snap-simple-keyring v2.0.1

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -4089,6 +4089,9 @@
         },
         "2.0.0": {
           "checksum": "bFMN5hlkguPBHNaiusJPWZh6yhFnTShcY1mu0Ko5YMM="
+        },
+        "2.0.1": {
+          "checksum": "TfeKGNKMSPQqAKQ/IrnOaziMcLqC6tWSjKRWo5YHMLs="
         }
       }
     },


### PR DESCRIPTION
Adds newly published version of snap-simple-keyring to the registry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds a new version entry to the snap registry with its checksum and does not change runtime logic. Main risk is an incorrect checksum/version mapping causing fetch/verification failures for that snap version.
> 
> **Overview**
> Adds `2.0.1` to the `npm:@metamask/snap-simple-keyring-snap` entry in `src/registry.json`, including the published artifact checksum so the registry can serve/verify this new snap version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88e4a790f816f1370fa5c46a76fc8802dbdfde3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->