### PR TITLE
Add snap-simple-keyring v2.1.0

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -4092,6 +4092,9 @@
         },
         "2.0.1": {
           "checksum": "TfeKGNKMSPQqAKQ/IrnOaziMcLqC6tWSjKRWo5YHMLs="
+        },
+        "2.1.0": {
+          "checksum": "V1nc4Dr3tA6lrG2DKSmEzecmlFXsny+wcxz2SmVfJyY="
         }
       }
     },


### PR DESCRIPTION
Adds newly published version of snap-simple-keyring to the registry (previous one was missing methods we needed for e2e to work).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change, but a bad version/checksum entry could prevent consumers/tests from resolving the snap correctly.
> 
> **Overview**
> Adds `2.1.0` to the `npm:@metamask/snap-simple-keyring-snap` entry in `src/registry.json`, including its published checksum so the registry can serve this newer snap version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 446e6329c7218580f54f66d5715c36874061c83a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->