### PR TITLE
Update support contact for COTI Snap

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -5135,7 +5135,7 @@
         "description": "1. AES Key Management: Securely store and manage AES keys in MetaMask\n2. Confidential Tokens: View and manage confidential ERC-20 tokens\n3. NFT Support: Handle confidential NFTs with metadata\n4. Token Operations: Transfer and deposit tokens\n5. Secure Storage: Encrypted storage within MetaMask's secure environment\n6. COTI Network: Native support for COTI's confidential blockchain",
         "category": "interoperability",
         "support": {
-          "contact": "mailto:dev@coti.io",
+          "contact": "https://discord.gg/coti-foundation",
           "knowledgeBase": "https://docs.coti.io/coti-documentation/build-on-coti/tools/coti-metamask-snap"
         },
         "sourceCode": "https://github.com/coti-io/coti-snap"


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This update changes the support contact from an email address to a branded Discord link. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field in `registry.json` with no runtime or security impact.
> 
> **Overview**
> Updates the **COTI** MetaMask Snap registry entry so `support.contact` points to the **COTI Foundation Discord** (`https://discord.gg/coti-foundation`) instead of `mailto:dev@coti.io`. No snap version, checksum, or functional metadata changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63c1be3746d7dd0c1234823be5dc9ea6a729f13c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->