### PR TITLE
Update NEAR Protocol

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -2617,9 +2617,9 @@
         "name": "NEAR Protocol",
         "author": {
           "name": "HERE Wallet",
-          "website": "https://www.herewallet.app/"
+          "website": "https://hot-labs.org/"
         },
-        "website": "https://my.herewallet.app/",
+        "website": "https://hot-labs.org/",
         "summary": "View and sign transactions for NEAR Protocol.",
         "description": "View and sign transactions for NEAR Protocol blockchain.\n\nFeatures:\n1. You can create an account on NEAR Protocol with ed25519 key\n2. You can sign transactions on NEAR Protocol\n3. FT token transfers and token additions are visualized\n4. You can export keys to a third-party wallet\n5. Meta-transactions on NEAR Protocol are supported",
         "audits": [


### PR DESCRIPTION
Updates the website URLs for the `npm:@near-snap/plugin` (NEAR Protocol) registry entry.

* **Current state:** `metadata.website` points to `https://my.herewallet.app/` and `metadata.author.website` points to `https://www.herewallet.app/`.
* **Change:** Both URLs now point to `https://hot-labs.org/`, the correct upstream site for the snap publisher.

Context: https://consensys.slack.com/archives/CBHSSFEN5/p1779807079111949

Registry-data-only change — no schema, code, or version/checksum changes. `yarn lint:misc --check` and `yarn lint:changelog` pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry metadata URL corrections only; no functional, security, or package integrity changes.
> 
> **Overview**
> Updates **registry metadata only** for `npm:@near-snap/plugin` (NEAR Protocol): both `metadata.website` and `metadata.author.website` now point to `https://hot-labs.org/` instead of the previous HERE Wallet / `herewallet.app` URLs.
> 
> No snap version, checksum, schema, or application code changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba30c72c91747c197e65a2213ca896fc5dcb64c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->