### PR TITLE
ci: Add top-level permissions to publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,9 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
## Summary

Adds a top-level `permissions: contents: read` to the `publish-release` workflow to restrict default token permissions as a security best practice.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission hardening with no application logic changes; release jobs that need write access still declare it explicitly.
> 
> **Overview**
> Adds workflow-level **`permissions: contents: read`** to `publish-release.yml` so reusable runs default to read-only repo access instead of broader implicit `GITHUB_TOKEN` scopes.
> 
> The **`publish-release`** job still sets **`contents: write`** for release publishing, and **`publish-npm`** keeps its existing **`contents: read`** / **`id-token: write`** block; jobs without overrides (e.g. **`publish-npm-dry-run`**) now inherit the tighter default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffe00f0d769733db79e26450ef01e1871eecd10e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->