### PR TITLE
Remove Cosmos Wallet by Leap

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -1744,47 +1744,6 @@
         }
       }
     },
-    "npm:@leapwallet/metamask-cosmos-snap": {
-      "id": "npm:@leapwallet/metamask-cosmos-snap",
-      "metadata": {
-        "name": "Cosmos Wallet",
-        "author": {
-          "name": "Leap",
-          "website": "https://www.leapwallet.io/"
-        },
-        "website": "https://cosmos.leapwallet.io/snaps",
-        "summary": "Securely manage keys, connect to Cosmos dapps, and sign transactions.",
-        "description": "Securely manage keys, connect to Cosmos dapps, and sign transactions.\n\nAfter installing the Snap, visit the website to connect with MetaMask and start using the Snap.",
-        "audits": [
-          {
-            "auditor": "Sayfer",
-            "report": "https://github.com/MetaMask/snaps-registry/files/12544468/Sayfer.-.2023-08.Penetration.Testing.Report.for.LeapWallet.Snap.-.Updated.pdf"
-          }
-        ],
-        "category": "interoperability",
-        "support": {
-          "contact": "https://leapwallet.notion.site/Leap-Cosmos-Wallet-Support-ba1da3c05d3341eaa44a1850ed3260ee",
-          "faq": "https://leapwallet.notion.site/Leap-Cosmos-Wallet-Support-ba1da3c05d3341eaa44a1850ed3260ee#b9f076f6aeb947818b449a058cd2967b"
-        },
-        "sourceCode": "https://github.com/leapwallet/cosmos-metamask-snap",
-        "screenshots": [
-          "./images/@leapwallet/metamask-cosmos-snap/1.png",
-          "./images/@leapwallet/metamask-cosmos-snap/2.png",
-          "./images/@leapwallet/metamask-cosmos-snap/3.png"
-        ]
-      },
-      "versions": {
-        "0.1.21": {
-          "checksum": "O8AnRrDyQolfSUSxK7uZyf8GEK3KmF4+UE3Gx1uAr4M="
-        },
-        "0.1.18": {
-          "checksum": "zwTU57HXUX94fMIYhLMfYxAK/pGRwI0Dqao76/BqWZk="
-        },
-        "0.1.17": {
-          "checksum": "CLwZocaUEbDErtQAsybaudZDJq65a8AwlEFgkGUpmAQ="
-        }
-      }
-    },
     "npm:safe-send": {
       "id": "npm:safe-send",
       "metadata": {


### PR DESCRIPTION
> Leap Wallet and its associated products have been sunset on 28th May, 2026

Closes https://github.com/MetaMask/snaps-registry/issues/1496

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only deletion of a sunset snap; no runtime or security logic changes.
> 
> **Overview**
> **Removes** `npm:@leapwallet/metamask-cosmos-snap` (Cosmos Wallet by Leap) from `src/registry.json`, including its metadata, audit links, screenshots, and version checksums (`0.1.17`–`0.1.21`).
> 
> This aligns the registry with Leap Wallet’s product sunset (May 28, 2026) and closes the associated removal issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 788103a2597a56d635fa09cf8ee000865f201794. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->