### PR TITLE
fix: bump ins-snap-resolver to 0.1.1 (lower platformVersion for MM 11.1.0 compat)

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -5636,8 +5636,8 @@
         "sourceCode": "https://github.com/ItsGoonBoyCrypto/INSdomains/tree/main/snap"
       },
       "versions": {
-        "0.1.0": {
-          "checksum": "eR30Sd3707bsrGo7O99TXs/qdpreDwxy8BgmT54ShnE="
+        "0.1.1": {
+          "checksum": "H8rJHH07q7j6VVd/Sq4A8+3NjNQs11ENWqtHJp2RVws="
         }
       }
     },


### PR DESCRIPTION
## What

Bump `npm:ins-snap-resolver` from `0.1.0` → `0.1.1` and update the checksum to match the newly published bundle.

## Why

The `0.1.0` release was published declaring `platformVersion: "11.1.1"`. Users on current-stable MetaMask `11.1.0` hit a hard install failure:

> The Snap "npm:ins-snap-resolver" requires platform version "11.1.1" which is greater than the current platform version "11.1.0".

`0.1.1` pins `@metamask/snaps-sdk` to exact `11.0.0` so the auto-generated `platformVersion` drops to `11.0.0` and the snap installs cleanly on every current MM build.

## Compatibility risk

The snap only uses:

- `OnNameLookupHandler`
- `endowment:name-lookup`
- `endowment:network-access`
- standard `fetch`

All of these have been stable since `@metamask/snaps-sdk` 9.x, so the SDK downgrade has no functional impact.

## Verification

- **npm:** https://www.npmjs.com/package/ins-snap-resolver/v/0.1.1
- **Source diff:** https://github.com/ItsGoonBoyCrypto/INSdomains/commit/a1fe9f0
- **Built bundle:** https://github.com/ItsGoonBoyCrypto/INSdomains/blob/main/snap/dist/snap.js
- **Source:** https://github.com/ItsGoonBoyCrypto/INSdomains/tree/main/snap

Confirmed on the publishing side: bundle shasum matches manifest, manifest `version` matches `package.json`, package is publicly downloadable.

cc @Mrtenz (you handled #1504, sorry for the immediate followup)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-package version and checksum update in the registry; no application code changes and the snap’s APIs are unchanged per the PR description.
> 
> **Overview**
> Updates the allowlist entry for **`npm:ins-snap-resolver`** from **0.1.0** to **0.1.1** and replaces the bundle **checksum** so MetaMask installs the new published artifact.
> 
> This follows a **platform version** mismatch: **0.1.0** required Snaps platform **11.1.1**, which blocked installs on **11.1.0**. **0.1.1** lowers the declared platform requirement (via pinning **`@metamask/snaps-sdk`** to **11.0.0**) so current stable MetaMask can install the snap without changing INS name-resolution behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 477c29350ce5cf11a79f978b5b2c2ede7752e4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->