### PR TITLE
Remove CC Snap

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -5385,28 +5385,6 @@
         }
       }
     },
-    "npm:@nodefortress/cc-snap": {
-      "id": "npm:@nodefortress/cc-snap",
-      "metadata": {
-        "name": "CC by Node Fortress",
-        "author": {
-          "name": "Node Fortress",
-          "website": "https://nodefortress.io/"
-        },
-        "summary": "Manage Canton Network accounts and assets.",
-        "description": "After installing the app, visit the companion app at https://ccsnap.io to deploy your account.",
-        "category": "interoperability",
-        "support": {
-          "contact": "mailto:wallet@nodefortress.io"
-        },
-        "sourceCode": "https://github.com/nodefortress/cc-snap"
-      },
-      "versions": {
-        "0.1.14": {
-          "checksum": "zmCRkePVLGVlbdBjof52OQqh14qum8XUq/I2y407rHE="
-        }
-      }
-    },
     "npm:@taker007/crypto-guardian-snap": {
       "id": "npm:@taker007/crypto-guardian-snap",
       "metadata": {


### PR DESCRIPTION
As requested by the developer.

Closes #1500 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only deletion with no runtime or application code changes.
> 
> **Overview**
> Removes **`npm:@nodefortress/cc-snap`** (CC by Node Fortress) from `src/registry.json`, including its metadata and the `0.1.14` version checksum entry.
> 
> This delists the Canton Network account/asset management snap from the registry per developer request (closes #1500).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 029a67fd18733027cd939571b1176fc334aad562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->