### PR TITLE
ci: Setup token exchange for republishing directory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,6 @@ jobs:
       REGISTRY_PRIVATE_KEY: ${{ secrets.REGISTRY_PRIVATE_KEY }}
       REGISTRY_PUBLIC_KEY: ${{ secrets.REGISTRY_PUBLIC_KEY }}
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      REPUBLISH_DIRECTORY_TOKEN: ${{ secrets.REPUBLISH_DIRECTORY_TOKEN }}
 
   publish-test-registry:
     name: Publish test registry

--- a/.github/workflows/publish-registry.yml
+++ b/.github/workflows/publish-registry.yml
@@ -28,8 +28,6 @@ on:
         required: true
       SLACK_WEBHOOK_URL:
         required: false
-      REPUBLISH_DIRECTORY_TOKEN:
-        required: false
 
 jobs:
   check-updated:
@@ -146,9 +144,19 @@ jobs:
       - publish-registry
     runs-on: ubuntu-latest
     steps:
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          target-repository: 'MetaMask/snaps-directory'
+          permissions: |
+            contents: read
+            metadata: read
+            actions: write
       - uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.REPUBLISH_DIRECTORY_TOKEN }}
+          github-token: ${{ steps.get-token.outputs.token }}
           script: |
             await github.rest.actions.createWorkflowDispatch({
               owner: context.repo.owner,


### PR DESCRIPTION
Replace expired PAT with token exchange to automatically republish directory.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that swaps a static secret for scoped OIDC/token-exchange credentials; behavior of the directory republish dispatch should stay the same if `TOKEN_EXCHANGE_URL` is configured.
> 
> **Overview**
> **Replaces the long-lived `REPUBLISH_DIRECTORY_TOKEN` PAT** with a short-lived GitHub token from MetaMask’s `get-token` action when the prod registry publish job triggers `republish-release.yml` on `MetaMask/snaps-directory`.
> 
> The `republish-directory` job now requests a token via `${{ vars.TOKEN_EXCHANGE_URL }}` with `contents`/`metadata` read and `actions` write, then passes `steps.get-token.outputs.token` into `actions/github-script` for `createWorkflowDispatch`. The reusable workflow and `main.yml` no longer declare or forward the `REPUBLISH_DIRECTORY_TOKEN` secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 162963846d0ebd8f949419a98eb819bfb3f866fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->