### PR TITLE
Update TrustVault

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -2840,9 +2840,9 @@
           "name": "bitpanda",
           "website": "https://www.bitpanda.com"
         },
-        "website": "https://app.bitpandacustody.com",
+        "website": "https://bts-custody.bitpanda.com",
         "summary": "Connect Trust Vault wallets to MetaMask.",
-        "description": "1. Sign in to your Trust Vault account at https://app.bitpandacustody.com/\n2. Visit the Snap management page at https://app.bitpandacustody.com/metamask-snap\n3. Connect the Snap to Trust Vault\n4. Add Subwallets to MetaMask",
+        "description": "1. Sign in to your Trust Vault account at https://bts-custody.bitpanda.com\n2. Visit the Snap management page at https://bts-custody.bitpanda.com/metamask-snap\n3. Connect the Snap to Trust Vault\n4. Add Subwallets to MetaMask",
         "audits": [
           {
             "auditor": "Kudelski Security",
@@ -2858,6 +2858,9 @@
         "sourceCode": "https://github.com/bitpanda-labs/trust-vault-snap"
       },
       "versions": {
+        "1.1.7": {
+          "checksum": "sa8P3VF0QEIZH7qdffNzpmrHmdviieihihMN81qBbNM="
+        },
         "1.0.0": {
           "checksum": "RYAYosxly2V4GWk1KBOvZWOcl8t5iFw0Mkyi+vVqwVU="
         },


### PR DESCRIPTION
Update Trust Vault Snap website URL and add version 1.1.7

Point Trust Vault Snap links to the new bts-custody.bitpanda.com domain and register the checksum for version 1.1.7.

<!--

* The current Snap crashes often and has a graphQL injection risk. This version includes many fixes for many problems:
* fix: added content-type header for internal API calls
* fix: incompatibilities with latest version of metamask are resolved
* fix: race condition
* fix: password prompt always appearing
* chore: upgrading dependencies
* fix: reject cancelled personal_sign and signTypedData requests
* fix: refresh token failures & add set accounts
* fix: replaced GraphQL string interpolation with parameterised variables to prevent injection attacks
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only URL and version checksum updates with no application or auth logic changes.
> 
> **Overview**
> Updates **TrustVault** Snap registry metadata to use the **bts-custody.bitpanda.com** domain instead of **app.bitpandacustody.com** for the listing website and the sign-in / Snap management steps in the description.
> 
> Registers **version 1.1.7** with its npm package checksum so MetaMask can install and verify that release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fde76ab71ed33683c7d7c3d516820ec8bb39edf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->