### PR TITLE
Add Gwei Name Service

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -5698,6 +5698,30 @@
         }
       }
     },
+    "npm:@donnoh/gwei-name-service-snap": {
+      "id": "npm:@donnoh/gwei-name-service-snap",
+      "metadata": {
+        "name": "Gwei Name Service",
+        "author": {
+          "name": "Gwei Name Service",
+          "website": "https://gwei.domains"
+        },
+        "website": "https://gwei.domains",
+        "summary": "Resolve .gwei names and addresses natively in MetaMask.",
+        "description": "Gwei Name Service maps human-readable .gwei names to Ethereum addresses. The Snap lets users enter names such as alice.gwei directly in MetaMask recipient fields and returns forward-confirmed primary .gwei names for reverse lookups. It supports Ethereum mainnet and Sepolia. The Snap reads the immutable GNS NameNFT contracts through MetaMask's own Ethereum provider. It does not call external APIs or RPC endpoints, access accounts or keys, request network access, store data, sign transactions, or submit transactions. The published runtime has no dependencies. Source is MIT-licensed and fully open on GitHub.",
+        "category": "name resolution",
+        "support": {
+          "contact": "https://github.com/lucadonnoh/gwei-names/issues",
+          "knowledgeBase": "https://github.com/lucadonnoh/gwei-names/tree/main/snap#readme"
+        },
+        "sourceCode": "https://github.com/lucadonnoh/gwei-names/tree/main/snap"
+      },
+      "versions": {
+        "0.1.0": {
+          "checksum": "msxpU9suBlS4btUwM5DftmDiSn7xcaODHketk9bXoTE="
+        }
+      }
+    },
     "npm:@metamask/bitcoin-wallet-snap": {
       "id": "npm:@metamask/bitcoin-wallet-snap",
       "metadata": {


### PR DESCRIPTION
Closes #1520

## Summary

Adds `npm:@donnoh/gwei-name-service-snap` to the verified Snaps registry as a name-resolution Snap at version `0.1.0`. The listing links the public source, website, support channel, and pins the published manifest checksum.

Gwei Name Service provides forward and reverse `.gwei` resolution on Ethereum mainnet and Sepolia. It reads the GNS contracts through the MetaMask Ethereum provider and has no runtime dependencies, external network access, account access, state, or signing capability.

## Validation

- `yarn test` (11 tests, 100% coverage)
- `yarn build`
- `yarn lint:misc --check`
- `yarn verify-snaps --diff`
- public npm package checksum verified against the manifest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only metadata addition with no application or runtime code changes; risk is limited to listing accuracy of the pinned checksum and descriptions.
> 
> **Overview**
> Adds a verified registry entry for **`npm:@donnoh/gwei-name-service-snap`** at version **`0.1.0`**, categorized as **name resolution**, with metadata (summary, description, author/website, support links, open-source URL) and a pinned manifest checksum.
> 
> The listing documents forward/reverse **`.gwei`** resolution on Ethereum mainnet and Sepolia via on-chain GNS contracts through MetaMask’s provider, with no external APIs, account/key access, or signing described in the entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8df0661bf0916aa449984cf32c7a9691c1557f07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->