### PR TITLE
Update UTU Trust

### DIFF
--- a/src/registry.json
+++ b/src/registry.json
@@ -5080,11 +5080,8 @@
         "sourceCode": "https://gitlab.com/ututrust/utu-metamask-snap"
       },
       "versions": {
-        "1.10.15": {
-          "checksum": "TzjIsdUK6/KwJ9oM1dfbUsLGU1fhgGTsZ2Fs4CBWVJg="
-        },
-        "1.10.13": {
-          "checksum": "wZmm7zb+sGEEet9C4XHHVlRDA1pym4CLBH+V1bege6M="
+        "1.12.0": {
+          "checksum": "Fq01AvnFikO6119+4a1jL/90SX21Eo8kEOmR4D6ddqI="
         }
       }
     },


### PR DESCRIPTION
This closes #1524

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only version and checksum update with no application or security logic changes.
> 
> **Overview**
> Updates the **UTU Trust** snap (`npm:@ututrust/utu-metamask-snap`) in `registry.json` to publish **1.12.0** with its integrity checksum.
> 
> Older listed versions **1.10.15** and **1.10.13** are removed so only **1.12.0** remains in the registry entry. Snap metadata (description, links, category) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 895b76677b82f791ba1e5490d35cdfc93be4494f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->